### PR TITLE
Update notificationsChannelURL to api.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -63,7 +63,7 @@ export const notificationsChannelURLFromHookURL = hookURL => {
   if (hookURL.includes('twyla.io')) {
     environment = /api\.(.*)\.twyla/.exec(hookURL)[1];
 
-    notificationsChannelURL = `wss://notification.${environment}.twyla.io/widget-notifications/${
+    notificationsChannelURL = `wss://api.${environment}.twyla.io/widget-notifications/${
       hookURLTokens[4]
     }/${hookURLTokens[5]}`;
   } else {

--- a/src/tests/index.test.js
+++ b/src/tests/index.test.js
@@ -10,7 +10,7 @@ describe('notificationsChannelURLFromHookURL tests', () => {
     ).toEqual({
       botName: 'Z10',
       notificationsChannelURL:
-        'wss://notification.production.twyla.io/widget-notifications/massive-dynamic/z10',
+        'wss://api.production.twyla.io/widget-notifications/massive-dynamic/z10',
     });
 
     // demo
@@ -20,8 +20,7 @@ describe('notificationsChannelURLFromHookURL tests', () => {
       )
     ).toEqual({
       botName: 'Z10',
-      notificationsChannelURL:
-        'wss://notification.demo.twyla.io/widget-notifications/massive-dynamic/z10',
+      notificationsChannelURL: 'wss://api.demo.twyla.io/widget-notifications/massive-dynamic/z10',
     });
   });
 


### PR DESCRIPTION
- Hit `wss://api.canvas.twyla.ai` instead of `wss://notification.canvas.twyla.ai`
- Or `wss://api.{env}.canvas.twyla.ai`